### PR TITLE
make #[feature(test)] test/bench-only

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(specialization)]
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
+#![cfg(test)]
 extern crate test;
 extern crate memchr;
 


### PR DESCRIPTION
This is one of two changes to make needle buildable on stable Rust.